### PR TITLE
~/.local/bin/ not available on Mac, pip3 installs twint to /usr/local/bin/

### DIFF
--- a/src/findka/hallway/api.clj
+++ b/src/findka/hallway/api.clj
@@ -65,7 +65,7 @@
                   :author author})))))
 
 (defn search-twitter [subject-url]
-  (->> (sh/sh ".local/bin/twint" "-s" subject-url "--format"
+  (->> (sh/sh "/usr/local/bin/twint" "-s" subject-url "--format"
               ">>> {username} {id} {date}T{time} {replies} {retweets} {likes} {tweet}"
               "-pt" "--limit" "20" :dir (System/getProperty "user.home"))
        :out


### PR DESCRIPTION
This fix works for Mac development. I haven't deployed to Unbuntu to test, just pointing out ~/.local seems env specific?